### PR TITLE
Fix typo to allow compiling under non-windows systems

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 
 #include <FS.h>
 #include <ArduinoOTA.h>
-#include <Time.h>
+#include <time.h>
 
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>


### PR DESCRIPTION
See [this issue](https://community.platformio.org/t/build-error-if-time-library-is-installed/450)